### PR TITLE
Updated deploy.yml to line up with the docs

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -27,6 +27,10 @@ jobs:
         uses: actions/checkout@v2          
       - name: Install, build, and upload your site output
         uses: withastro/action@v0
+        # with:
+            # path: . # The root location of your Astro project inside the repository. (optional)
+            # node-version: 16 # The specific version of Node that should be used to build your site. Defaults to 16. (optional)
+            # package-manager: yarn # The Node package manager that should be used to install dependencies and build your site. Automatically detected based on your lockfile. (optional)
 
   deploy:
     needs: build


### PR DESCRIPTION
This updates the deploy.yml workflow to line up with the docs.astro.build copy (https://github.com/withastro/docs/pull/1718)